### PR TITLE
Added sorting for app names in cli `status`

### DIFF
--- a/score/deploy/cli.py
+++ b/score/deploy/cli.py
@@ -91,7 +91,7 @@ def status(ctx):
     """
     Status info on deployment
     """
-    for name in ctx.obj.deploy.apps:
+    for name in sorted(ctx.obj.deploy.apps):
         app = ctx.obj.deploy.apps[name]
         print(name)
         for zergling in sorted(app.zerglings(), key=lambda z: z.name):


### PR DESCRIPTION
While using this module in production the listing of apps sometimes is shuffled, which is a bit of an annoyance. A simple sorting on app names resolves this.
